### PR TITLE
PouchDB Server

### DIFF
--- a/bin/pouchdb-server
+++ b/bin/pouchdb-server
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+var path = require('path');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var spawn = require('child_process').spawn;
+var kazanaConfig = require('kazana-config');
+
+var port = kazanaConfig.pouchdbServerPort;
+var dataPath = kazanaConfig.pouchdbDataPath;
+var configFilePath = path.resolve(dataPath, 'config.json');
+
+try {
+  require(configFilePath);
+} catch (error) {
+  mkdirp.sync('./.db');
+  var pouchdbConfig = {
+    log: {
+      file: './.db/log.txt'
+    },
+    admins: {}
+  };
+  pouchdbConfig.admins[kazanaConfig.pouchdbHttpAdminUser] = kazanaConfig.pouchdbHttpAdminPass;
+  fs.writeFileSync(configFilePath, JSON.stringify(pouchdbConfig, null, 4));
+}
+
+var pouchDbBinPath = path.resolve(__dirname, '../node_modules/.bin/pouchdb-server');
+spawn(pouchDbBinPath, ['-p', port, '-d', dataPath, '-c', configFilePath], {
+  stdio: 'inherit'
+});

--- a/bin/server
+++ b/bin/server
@@ -4,11 +4,22 @@
 var Kazana = require('../index');
 var main = require(process.cwd());
 var argv = require('minimist')(process.argv.slice(2));
+var kazanaConfig = require('kazana-config');
+
+if (kazanaConfig.pouchdbHttpUrl) {
+  console.log('Connected to CouchDB at %s', kazanaConfig.pouchdbHttpUrl);
+} else {
+  kazanaConfig.pouchdbHttpUrl = 'http://localhost:' + kazanaConfig.pouchdbServerPort
+  console.log('KAZANA_POUCHDB_HTTP_URL not set, starting PouchDB Server at %s ...', kazanaConfig.pouchdbServerPort)
+  require('./pouchdb-server')
+}
+
 var kazana = new Kazana(main, {
 
   // if set to true, core modules like the kazana-raw-data do not get loaded
   bare: argv.bare
 });
+
 kazana.start(function () {
   console.log('Server running at %s', kazana.info.uri);
 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.0-semantically-released",
   "description": "A modular data warehouse system",
   "main": "index.js",
-  "bin": "./bin/server",
+  "bin": {
+    "kazana": "./bin/server",
+    "kazana-database": "./bin/pouchdb-server"
+  },
   "scripts": {
     "start": "./bin/server",
     "test": "semistandard",
@@ -38,14 +41,16 @@
     "joi": "^6.6.1",
     "kazana-account": "^1.0.0",
     "kazana-bootstrap": "^1.0.4",
-    "kazana-config": "^1.0.1",
+    "kazana-config": "git://github.com/eHealthAfrica/kazana-config#pouchdb-server",
     "kazana-raw-data": "^1.1.0",
     "lodash": "^3.10.0",
     "lout": "^6.2.3",
     "minimist": "^1.1.2",
+    "mkdirp": "^0.5.1",
     "pouchdb": "^3.6.0",
     "pouchdb-authentication": "^0.4.1",
-    "pouchdb-hoodie-api": "^1.4.0"
+    "pouchdb-hoodie-api": "^1.4.0",
+    "pouchdb-server": "^0.6.6"
   },
   "devDependencies": {
     "semantic-release": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "joi": "^6.6.1",
     "kazana-account": "^1.0.0",
     "kazana-bootstrap": "^1.0.4",
-    "kazana-config": "git://github.com/eHealthAfrica/kazana-config#pouchdb-server",
+    "kazana-config": "^2.0.0",
     "kazana-raw-data": "^1.1.0",
     "lodash": "^3.10.0",
     "lout": "^6.2.3",


### PR DESCRIPTION
spawns a pouchdb-server if `KAZANA_POUCHDB_HTTP_URL` is not set.

Depends on https://github.com/eHealthAfrica/kazana-config/pull/1
(No need to npm link, is installed via package.json)