### PR TITLE
Add pinned and bundled components

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "hoek": "^2.14.0",
     "inert": "^3.0.1",
     "joi": "^6.6.1",
-    "kazana-account": "^2.0.0",
-    "kazana-bootstrap": "^1.0.4",
-    "kazana-config": "^5.0.0",
-    "kazana-raw-data": "^3.0.0",
+    "kazana-account": "2.0.0",
+    "kazana-bootstrap": "2.0.0",
+    "kazana-config": "5.0.0",
+    "kazana-raw-data": "3.0.0",
     "lodash": "^3.10.1",
     "lout": "^6.2.3",
     "minimist": "^1.1.3",
@@ -65,5 +65,11 @@
     "standard": "^5.1.0",
     "tap-spec": "^4.0.2",
     "tape": "^4.1.0"
-  }
+  },
+  "bundleDependencies": [
+    "kazana-account",
+    "kazana-bootstrap",
+    "kazana-config",
+    "kazana-raw-data"
+  ]
 }


### PR DESCRIPTION
Once https://github.com/eHealthAfrica/kazana-account/pull/2, https://github.com/eHealthAfrica/kazana-bootstrap/pull/6, https://github.com/eHealthAfrica/kazana-config/pull/6 and https://github.com/eHealthAfrica/kazana-raw-data/pull/5 are merged we can get rid of version ranges, still have up-to-date versions and, by running integration-tests every single time, make sure that every component release doesn't break kazana in it's entirety.

Together with the pinned versions I've added all components to the `"bundleDependencies"` field, which means during publish they're added to the kazana tarball. This is saving users **a lot** of roundtrips, which should cut down install time immensely. Also this gives us deterministic "kazana" installs, because one version of kazana always has the same internal dependency structure. This should make error reports way easier to debug.