### PR TITLE
Pin and (auto-)bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,41 +35,49 @@
   },
   "homepage": "https://github.com/eHealthAfrica/kazana#readme",
   "dependencies": {
-    "boom": "^2.8.0",
-    "good": "^6.3.0",
-    "good-console": "^5.0.2",
-    "h2o2": "^4.0.1",
-    "hapi": "^9.0.1",
-    "hapi-cors-headers": "^1.0.0",
-    "hoek": "^2.14.0",
-    "inert": "^3.0.1",
-    "joi": "^6.6.1",
+    "boom": "2.8.0",
+    "good": "6.3.0",
+    "good-console": "5.0.2",
+    "h2o2": "4.0.1",
+    "hapi": "9.0.1",
+    "hapi-cors-headers": "1.0.0",
+    "hoek": "2.14.0",
+    "inert": "3.0.1",
+    "joi": "6.6.1",
     "kazana-account": "2.0.0",
     "kazana-bootstrap": "2.0.0",
     "kazana-config": "5.0.0",
     "kazana-raw-data": "3.0.0",
-    "lodash": "^3.10.1",
-    "lout": "^6.2.3",
-    "minimist": "^1.1.3",
-    "pouchdb": "^4.0.0",
-    "pouchdb-authentication": "^0.4.1",
-    "pouchdb-hoodie-api": "^1.4.1",
-    "spawn-pouchdb-server": "^3.0.0",
-    "vision": "^2.0.1"
+    "lodash": "3.10.1",
+    "lout": "7.0.0",
+    "minimist": "1.1.3",
+    "pouchdb": "4.0.0",
+    "pouchdb-authentication": "0.4.1",
+    "pouchdb-hoodie-api": "1.4.1",
+    "spawn-pouchdb-server": "3.0.0",
+    "vision": "3.0.0"
   },
   "devDependencies": {
-    "istanbul": "^0.3.17",
-    "istanbul-coveralls": "^1.0.3",
+    "istanbul": "0.3.17",
+    "istanbul-coveralls": "1.0.3",
     "kazana-integration-test": "latest",
-    "semantic-release": "^4.0.3",
-    "standard": "^5.1.0",
-    "tap-spec": "^4.0.2",
-    "tape": "^4.1.0"
+    "semantic-release": "4.0.3",
+    "standard": "5.1.0",
+    "tap-spec": "4.0.2",
+    "tape": "4.1.0"
   },
   "bundleDependencies": [
     "kazana-account",
     "kazana-bootstrap",
     "kazana-config",
     "kazana-raw-data"
-  ]
+  ],
+  "greenkeeper": {
+    "ignore": [
+      "kazana-account",
+      "kazana-bootstrap",
+      "kazana-config",
+      "kazana-raw-data"
+    ]
+  }
 }


### PR DESCRIPTION
I've pinned and manually bumped all dependencies one last time. From now on the @ehealthafrica-ci bot will send pull-requests in real-time, whenever a dependency changes. That way each new version can be tested in isolation, which means we can keep all dependencies up-to-date with the click of the merge button, while identifying breaking changes immediately.

Additionally I've added configuration so the core kazana-components are ignored by this service, because they're already taken care of by bundle-bump-bot.