### PR TITLE
feat: add pending filter to submissions ddoc

### DIFF
--- a/bootstrap/raw-data/_design/submissions/filter.js
+++ b/bootstrap/raw-data/_design/submissions/filter.js
@@ -1,0 +1,6 @@
+module.exports = function (doc, req) {
+  if (doc.type !== 'dataReport') return false
+  if (doc.transformedAt) return false
+
+  return doc.sourceId === req.query.sourceId
+}

--- a/bootstrap/raw-data/_design/submissions/index.js
+++ b/bootstrap/raw-data/_design/submissions/index.js
@@ -4,5 +4,8 @@ module.exports = {
       map: require('./map'),
       reduce: '_count'
     }
+  },
+  filters: {
+    pending: require('./filter')
   }
 }


### PR DESCRIPTION
This adds a filter to the submissions design documents which filters out all
pending submissions doc for a sourceId which must be provided as query
parameter.

Closes #65