### PR TITLE
Updated kazana-integration-test to version 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bundle-bump-bot": "1.1.0",
     "dynamic-bundle": "1.0.0",
     "istanbul": "0.3.22",
-    "kazana-integration-test": "1.1.3",
+    "kazana-integration-test": "1.2.0",
     "semantic-release": "4.3.5"
   },
   "greenkeeper": {


### PR DESCRIPTION
:rocket:

kazana-integration-test just published version 1.2.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/eHealthAfrica/kazana-integration-test/releases/tag/v1.2.0)

<a name"1.2.0"></a>
## 1.2.0 (2015-10-06)


#### Features

* add integration tests for kazana-example ([0204a43d](https://github.com/eHealthAfrica/kazana-integration-test/commit/0204a43d))

---
The new version differs by 12 commits (ahead by 12, behind by 0).

- [a4e1642](https://github.com/eHealthAfrica/kazana-integration-test/commit/a4e1642c8570ef7304c0069d569abd450c08779c): Merge pull request #4 from eHealthAfrica/feature/write-tests
- [0204a43](https://github.com/eHealthAfrica/kazana-integration-test/commit/0204a43d7fa22bcdb5ca140798551c5709a9a28d): feat: add integration tests for kazana-example
- [ce8b29a](https://github.com/eHealthAfrica/kazana-integration-test/commit/ce8b29afe38550831dd1cc124ab2f7a04f8d14f7): Merge pull request #6 from eHealthAfrica/greenkeeper-kazana-example-2.9.0
- [3d23140](https://github.com/eHealthAfrica/kazana-integration-test/commit/3d231405b6febcfedb739787dec51888e3808be9): chore(package): update kazana-example to version 2.9.0
- [cb2ef8b](https://github.com/eHealthAfrica/kazana-integration-test/commit/cb2ef8b3cc07a0c3689d8625d4968a27d2e97448): Merge pull request #5 from eHealthAfrica/greenkeeper-kazana-example-2.8.3
- [1ea3e99](https://github.com/eHealthAfrica/kazana-integration-test/commit/1ea3e993eee92ae280eeb3770ca4294e08979bca): chore(package): update kazana-example to version 2.8.3
- [b404611](https://github.com/eHealthAfrica/kazana-integration-test/commit/b4046113e7c0ba702ecc8e8aaaf46de71c2c2d10): Merge pull request #3 from eHealthAfrica/greenkeeper-kazana-example-2.8.2
- [fba7bc4](https://github.com/eHealthAfrica/kazana-integration-test/commit/fba7bc4bbda759d21fef000ac058007e4500b961): chore(package): update kazana-example to version 2.8.2
- [15d1c2e](https://github.com/eHealthAfrica/kazana-integration-test/commit/15d1c2e8b710bb9981502ee367ed93ab38179a13): Merge pull request #2 from eHealthAfrica/greenkeeper-pin
- [2967375](https://github.com/eHealthAfrica/kazana-integration-test/commit/2967375b96394c60b124eb8222ae9e1d30c54cc8): chore(package): pin dependencies
- [9c1f72d](https://github.com/eHealthAfrica/kazana-integration-test/commit/9c1f72d32bed95e33a64e597a37448d412d2bf21): Merge pull request #1 from eHealthAfrica/add-license-file
- [1103eed](https://github.com/eHealthAfrica/kazana-integration-test/commit/1103eeda09e667d817df04eb8218dc235e3a1e44): docs(license): Add license file

See the [full diff](https://github.com/eHealthAfrica/kazana-integration-test/compare/967c7007e69265e082517abeb099f6dde6c9bfab...a4e1642c8570ef7304c0069d569abd450c08779c).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>