### PR TITLE
fix: change `static` manifest property to `public`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 module.exports = {
   name: 'myapp',
   version: '1.0.0',
-  static: 'public',
+  public: 'public',
   routes: routes,
   bootstrap: 'bootstrap',
   indices: {
@@ -57,12 +57,12 @@ Name of the app / plugin
 
 Default port number for app.
 
-### static
+### public
 
-Path to folder from where to serve static assets at the root path.
+Path to folder from where to serve public assets at the root path.
 
 ```js
-  static: 'public'
+  public: 'public'
 ```
 
 Is simply a shortcut for
@@ -128,7 +128,7 @@ Array of objects with same properties as `options` for the
 ### kazana-services
 
 ```
-$ kazana-services 
+$ kazana-services
 npm start -- --only=account
 npm start -- --only=raw-data
 npm start -- --bare

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require('path')
 module.exports = {
   name: 'kazana',
   version: require('./package.json').version,
-  static: path.resolve(__dirname, 'public'),
+  public: path.resolve(__dirname, 'public'),
   bootstrap: path.resolve(__dirname, 'bootstrap'),
   plugins: [
     require('kazana-account'),


### PR DESCRIPTION
BREAKING CHANGE: The `static` manifest property has been changed to
`public` as a precaution against a potential incompatibility with the es7 stage 0 class
properties syntax.

https://github.com/jeffmo/es-class-static-properties-and-fields

Closes https://github.com/eHealthAfrica/kazana/issues/82